### PR TITLE
Execute AttributeChangedValueEvent only once on update

### DIFF
--- a/src/main/java/dev/shadowsoffire/attributeslib/mixin/AttributeMapMixin.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/mixin/AttributeMapMixin.java
@@ -1,5 +1,8 @@
 package dev.shadowsoffire.attributeslib.mixin;
 
+import com.mojang.datafixers.util.Pair;
+import dev.shadowsoffire.attributeslib.util.IAttributeManager;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,6 +15,9 @@ import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeMap;
 import net.minecraftforge.common.MinecraftForge;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * For the {@link AttributeChangedValueEvent} to have the necessary entity context, the attribute map must be aware of the owning entity.<br>
  * Once that context is known, firing the event is a hook in {@link AttributeMap#onAttributeModified}.
@@ -19,9 +25,11 @@ import net.minecraftforge.common.MinecraftForge;
  * The client event is posted from the client packet listener as this method is unreliable on the client due to how attribute sync is done.
  */
 @Mixin(AttributeMap.class)
-public class AttributeMapMixin implements IEntityOwned {
+public class AttributeMapMixin implements IEntityOwned, IAttributeManager {
 
     protected LivingEntity owner;
+    private boolean areAttributesUpdating;
+    private Map<Attribute, Pair<AttributeInstance, Double>> updatingAttributes = new HashMap<>();
 
     @Override
     public LivingEntity getOwner() {
@@ -35,6 +43,29 @@ public class AttributeMapMixin implements IEntityOwned {
         this.owner = owner;
     }
 
+    @Override
+    public boolean areAttributesUpdating() {
+        return this.areAttributesUpdating;
+    }
+
+    @Override
+    public void setAttributesUpdating(boolean updating) {
+        this.areAttributesUpdating = updating;
+
+        // If the attributes are being updated, clear the updating list
+        if (this.areAttributesUpdating()) {
+            this.updatingAttributes.clear();
+        } else {
+            // Otherwise, cycle through each instance and get the new values, post the results
+            if (!this.getOwner().level().isClientSide) {
+                this.updatingAttributes.forEach((attr, pair) -> MinecraftForge.EVENT_BUS.post(new AttributeChangedValueEvent(this.getOwner(), pair.getFirst(), pair.getSecond(), pair.getFirst().getValue())));
+            }
+
+            // Extra clear in case of weird behavior
+            this.updatingAttributes.clear();
+        }
+    }
+
     /**
      * Serverside call site for {@link AttributeChangedValueEvent}. Uses the built-in hook {@link AttributeMap#onAttributeModified} and the stapled-in entity
      * context.
@@ -43,13 +74,16 @@ public class AttributeMapMixin implements IEntityOwned {
      */
     @Inject(at = @At(value = "HEAD"), method = "onAttributeModified(Lnet/minecraft/world/entity/ai/attributes/AttributeInstance;)V", require = 1)
     public void apoth_attrModifiedEvent(AttributeInstance inst, CallbackInfo ci) {
-        if (!owner.level().isClientSide) {
+        if (!this.areAttributesUpdating() && !owner.level().isClientSide) {
             // This call site is only valid on the server, because the client nukes and reapplies all attribute modifiers when received.
             double oldValue = ((AttributeInstanceAccessor) inst).getCachedValue();
             double newValue = inst.getValue(); // Calling getValue will compute the value once marked dirty.
             if (oldValue != newValue) {
                 MinecraftForge.EVENT_BUS.post(new AttributeChangedValueEvent(getOwner(), inst, oldValue, newValue));
             }
+        } else if (this.areAttributesUpdating()) {
+            // If attributes are being updated, store the instance and previous value for exectuion after update
+            this.updatingAttributes.putIfAbsent(inst.getAttribute(), Pair.of(inst, ((AttributeInstanceAccessor) inst).getCachedValue()));
         }
     }
 

--- a/src/main/java/dev/shadowsoffire/attributeslib/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/mixin/LivingEntityMixin.java
@@ -2,6 +2,7 @@ package dev.shadowsoffire.attributeslib.mixin;
 
 import javax.annotation.Nullable;
 
+import dev.shadowsoffire.attributeslib.util.IAttributeManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -93,4 +94,21 @@ public abstract class LivingEntityMixin extends Entity {
         return ALCombatRules.getDamageAfterProtection((LivingEntity) (Object) this, src, amount, protPoints);
     }
 
+    /**
+     * @author ChampionAsh5357
+     * @reason Lock attribute updates for event until after new modifiers are added
+     */
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/effect/MobEffect;removeAttributeModifiers(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/ai/attributes/AttributeMap;I)V"), method = "onEffectUpdated", require = 1)
+    public void apoth_onEffectUpdateRemoveAttribute(MobEffectInstance pEffectInstance, boolean pForced, Entity pEntity, CallbackInfo ci) {
+        ((IAttributeManager) attributes).setAttributesUpdating(true);
+    }
+
+    /**
+     * @author ChampionAsh5357
+     * @reason Unlock attribute updates for event until after new modifiers are added
+     */
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/effect/MobEffect;addAttributeModifiers(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/ai/attributes/AttributeMap;I)V", shift = At.Shift.AFTER), method = "onEffectUpdated", require = 1)
+    public void apoth_onEffectUpdateAddAttribute(MobEffectInstance pEffectInstance, boolean pForced, Entity pEntity, CallbackInfo ci) {
+        ((IAttributeManager) attributes).setAttributesUpdating(false);
+    }
 }

--- a/src/main/java/dev/shadowsoffire/attributeslib/util/IAttributeManager.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/util/IAttributeManager.java
@@ -1,0 +1,22 @@
+package dev.shadowsoffire.attributeslib.util;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A manager for handling weird attribute logic within Minecraft.
+ */
+@ApiStatus.Internal
+public interface IAttributeManager {
+
+    /**
+     * {@return whether the attributes are being updated, instead of added or removed}
+     */
+    boolean areAttributesUpdating();
+
+    /**
+     * Sets whether the attributes are being updated, instead of added or removed.
+     *
+     * @param updating whether the attributes are being updated, instead of added or removed
+     */
+    void setAttributesUpdating(boolean updating);
+}


### PR DESCRIPTION
Closes Shadows-of-Fire/Apotheosis#1022

Changes the logic such that `AttributeChangedValueEvent` is called once per attribute on update rather than on removal and rendition. This fixes some logic that checks the new value and sees that the attribute was removed.