### PR TITLE
Made Attributes GUI button visible and functional in Curios GUI

### DIFF
--- a/src/main/java/dev/shadowsoffire/attributeslib/AttributesLib.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/AttributesLib.java
@@ -2,6 +2,7 @@ package dev.shadowsoffire.attributeslib;
 
 import java.util.function.BiConsumer;
 
+import dev.shadowsoffire.attributeslib.client.CuriosClientCompat;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -131,6 +132,7 @@ public class AttributesLib {
         }
         if (ModList.get().isLoaded("curios")) {
             e.enqueueWork(CuriosCompat::init);
+            MinecraftForge.EVENT_BUS.register(new CuriosClientCompat());
         }
     }
 

--- a/src/main/java/dev/shadowsoffire/attributeslib/AttributesLib.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/AttributesLib.java
@@ -2,6 +2,7 @@ package dev.shadowsoffire.attributeslib;
 
 import java.util.function.BiConsumer;
 
+import dev.shadowsoffire.attributeslib.client.CuriosClientCompat;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -65,6 +66,7 @@ public class AttributesLib {
         MinecraftForge.EVENT_BUS.register(new AttributeEvents());
         if (FMLEnvironment.dist.isClient()) {
             MinecraftForge.EVENT_BUS.register(new AttributesLibClient());
+            MinecraftForge.EVENT_BUS.register(new CuriosClientCompat());
             FMLJavaModLoadingContext.get().getModEventBus().register(AttributesLibClient.class);
         }
 

--- a/src/main/java/dev/shadowsoffire/attributeslib/client/AttributesGui.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/client/AttributesGui.java
@@ -64,6 +64,7 @@ public class AttributesGui implements Renderable, GuiEventListener {
     protected static float scrollOffset = 0;
     // Ditto.
     protected static boolean hideUnchanged = false;
+    protected static boolean swappedFromCurios = false;
 
     protected final InventoryScreen parent;
     protected final Player player;

--- a/src/main/java/dev/shadowsoffire/attributeslib/client/AttributesLibClient.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/client/AttributesLibClient.java
@@ -113,7 +113,8 @@ public class AttributesLibClient {
             e.addListener(atrComp);
             e.addListener(atrComp.toggleBtn);
             e.addListener(atrComp.hideUnchangedBtn);
-            if (AttributesGui.wasOpen) atrComp.toggleVisibility();
+            if (AttributesGui.wasOpen || AttributesGui.swappedFromCurios) atrComp.toggleVisibility();
+            AttributesGui.swappedFromCurios = false;
         }
     }
 

--- a/src/main/java/dev/shadowsoffire/attributeslib/client/CuriosClientCompat.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/client/CuriosClientCompat.java
@@ -1,0 +1,36 @@
+package dev.shadowsoffire.attributeslib.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.ImageButton;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.client.event.ScreenEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
+import top.theillusivec4.curios.client.gui.CuriosScreen;
+
+import static dev.shadowsoffire.attributeslib.client.AttributesGui.TEXTURES;
+import static dev.shadowsoffire.attributeslib.client.AttributesGui.WIDTH;
+
+public class CuriosClientCompat {
+
+    static {
+        if (!ModList.get().isLoaded("curios")) {
+            throw new UnsupportedOperationException("This other optional compat class requires Curios to be loaded.");
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void addAttribComponent(ScreenEvent.Init.Post e) {
+        if (e.getScreen() instanceof CuriosScreen scn) {
+            ImageButton button = new ImageButton(scn.getGuiLeft() + 63, scn.getGuiTop() + 10, 10, 10, WIDTH, 0, 10, TEXTURES, 256, 256, btn -> {
+                if (Minecraft.getInstance().player == null) return;
+                InventoryScreen invScn = new InventoryScreen(Minecraft.getInstance().player);
+                AttributesGui.swappedFromCurios = true;
+                scn.getMinecraft().setScreen(invScn);
+            }, Component.translatable("attributeslib.gui.show_attributes"));
+            e.addListener(button);
+        }
+    }
+}

--- a/src/main/java/dev/shadowsoffire/attributeslib/client/CuriosClientCompat.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/client/CuriosClientCompat.java
@@ -1,0 +1,29 @@
+package dev.shadowsoffire.attributeslib.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.ImageButton;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.client.event.ScreenEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import top.theillusivec4.curios.client.gui.CuriosScreen;
+
+import static dev.shadowsoffire.attributeslib.client.AttributesGui.TEXTURES;
+import static dev.shadowsoffire.attributeslib.client.AttributesGui.WIDTH;
+
+public class CuriosClientCompat {
+
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void addAttribComponent(ScreenEvent.Init.Post e) {
+        if (e.getScreen() instanceof CuriosScreen scn) {
+            ImageButton button = new ImageButton(scn.getGuiLeft() + 63, scn.getGuiTop() + 10, 10, 10, WIDTH, 0, 10, TEXTURES, 256, 256, btn -> {
+                if (Minecraft.getInstance().player == null) return;
+                InventoryScreen invScn = new InventoryScreen(Minecraft.getInstance().player);
+                AttributesGui.swappedFromCurios = true;
+                scn.getMinecraft().setScreen(invScn);
+            }, Component.translatable("attributeslib.gui.show_attributes"));
+            e.addListener(button);
+        }
+    }
+}


### PR DESCRIPTION
Currently, the Attributes GUI toggle button vanishes when the Curios GUI is opened. This pull request makes it so the Attributes GUI toggle button renders in the Curios GUI, and allows the player to swap from it to the Attributes GUI and vice versa.