### PR TITLE
Replace @Overwrite with @ModifyReturnValue, fixing mod incompats.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,10 @@ dependencies {
     if(project.hasProperty('twilightFileId'))       implementation fg.deobf("curse.maven:the-twilight-forest-227639:${twilightFileId}")
     if(project.hasProperty('gatewaysVersion'))      implementation fg.deobf("dev.shadowsoffire:GatewaysToEternity:${mcVersion}-${gatewaysVersion}")
     if(project.hasProperty('attributeslibVersion')) implementation fg.deobf("dev.shadowsoffire:ApothicAttributes:${mcVersion}-${attributeslibVersion}")
+    
+    implementation(jarJar("io.github.llamalad7:mixinextras-neoforge:0.3.5")) {
+        jarJar.ranged(it, "[0.3.5,)")
+    }
 }
 
 mixin {

--- a/src/main/java/dev/shadowsoffire/attributeslib/mixin/CombatRulesMixin.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/mixin/CombatRulesMixin.java
@@ -1,7 +1,9 @@
 package dev.shadowsoffire.attributeslib.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 
 import dev.shadowsoffire.attributeslib.AttributesLib;
 import dev.shadowsoffire.attributeslib.api.ALCombatRules;
@@ -15,16 +17,16 @@ public class CombatRulesMixin {
     /**
      * @see {@link ALCombatRules#getDamageAfterProtection(net.minecraft.world.entity.LivingEntity, net.minecraft.world.damagesource.DamageSource, float, float)}
      */
-    @Overwrite
-    public static float getDamageAfterMagicAbsorb(float damage, float protPoints) {
+    @ModifyReturnValue(method = "getDamageLeft", at = @At("RETURN"))
+    public static float getDamageAfterMagicAbsorb(float original, float damage, float protPoints) {
         return damage * ALCombatRules.getProtDamageReduction(protPoints);
     }
 
     /**
      * @see {@link ALCombatRules#getDamageAfterArmor(LivingEntity, DamageSource, float, float, float)}
      */
-    @Overwrite
-    public static float getDamageAfterAbsorb(float damage, float armor, float toughness) {
+    @ModifyReturnValue(method = "getInflictedDamage", at = @At("RETURN"))
+    public static float getDamageAfterAbsorb(float original, float damage, float armor, float toughness) {
         AttributesLib.LOGGER.trace("Invocation of CombatRules#getDamageAfterAbsorb is bypassing armor pen.");
         return damage * ALCombatRules.getArmorDamageReduction(damage, armor);
     }


### PR DESCRIPTION
[This mixin](https://github.com/Shadows-of-Fire/Apothic-Attributes/blob/1.20/src/main/java/dev/shadowsoffire/attributeslib/mixin/CombatRulesMixin.java) uses `@Overwrite` to return its own damage values, but sadly overwrite is bad for these cases, due to incompatibilities.

This specifically breaks my mod, Protection Balancer, which also mixins in the same place to modify the protection and armor values. It may break other mods too but i'm not aware of any.

I simply added mixin extras (because even if it's included inside neoforge,it wouldn't let me compile without adding it into the build gradle), and changed the overwrite to work with mixinextra's `@ModifyReturnValue`, giving out the exact same result but without breaking other mods that try to do a similar thing.